### PR TITLE
Add /openra/link route for ingame key registration.

### DIFF
--- a/config/routing.yml
+++ b/config/routing.yml
@@ -1,3 +1,8 @@
-openra_openrauseraccounts_controller:
+openra_openrauseraccounts_fetchinfo:
     path: /openra/{type}/{fingerprint}
     defaults: { _controller: openra.openrauseraccounts.controller:fetchinfo }
+
+openra_openrauseraccounts_link:
+    path: /openra/link
+    defaults: { _controller: openra.openrauseraccounts.controller:link }
+

--- a/config/services.yml
+++ b/config/services.yml
@@ -5,6 +5,8 @@ services:
             - '@openra.openrauseraccounts.core'
             - '@dbal.conn'
             - '@config'
+            - '@request'
+            - '@auth.provider_collection'
     openra.openrauseraccounts.core:
         class: openra\openrauseraccounts\core\core
         arguments:

--- a/controller/main.php
+++ b/controller/main.php
@@ -9,6 +9,7 @@
  */
 
 namespace openra\openrauseraccounts\controller;
+use phpbb\request\request_interface;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -19,7 +20,7 @@ class main
 	private $core;
 	private $db;
 	private $config;
-	private $table_prefix;
+	private $request;
 
 	/**
 	 * Constructor
@@ -27,14 +28,14 @@ class main
 	 * @param \openra\openrauseraccounts\core\core $core
 	 * @param \phpbb\db\driver\driver_interface $db
 	 * @param \phpbb\config\config $config
+	 * @param request_interface $request phpBB request object
 	 */
-	public function __construct(\openra\openrauseraccounts\core\core $core, \phpbb\db\driver\driver_interface $db, \phpbb\config\config $config)
+	public function __construct(\openra\openrauseraccounts\core\core $core, \phpbb\db\driver\driver_interface $db, \phpbb\config\config $config, request_interface $request)
 	{
-		global $phpbb_container;
 		$this->core = $core;
 		$this->db = $db;
 		$this->config = $config;
-		$this->table_prefix = $phpbb_container->getParameter('core.table_prefix');
+		$this->request = $request;
 	}
 
 	/**
@@ -133,10 +134,116 @@ class main
 		}
 	}
 
+	/**
+	 * Controller for route /openra/link
+	 *
+	 * @return \Symfony\Component\HttpFoundation\Response A Symfony Response object
+	 */
+	public function link()
+	{
+		global $phpbb_container, $table_prefix;
+		$username = $this->request->variable('username', '', true);
+		$password = $this->request->variable('password', '', true);
+		$pubkey = $this->request->variable('pubkey', '');
+		$key_table = $table_prefix . 'openra_keys';
+
+		$provider_collection = $phpbb_container->get('auth.provider_collection');
+		$provider = $provider_collection->get_provider();
+		if ($provider)
+		{
+			$login = $provider->login($username, $password);
+			if ($login['status'] == LOGIN_SUCCESS)
+			{
+				if ($this->is_banned($login['user_row']['user_id']))
+				{
+					return $this->get_response("Error: banned");
+				}
+
+				// Sanity check the public key and calculate the fingerprint.
+				$fingerprint = '';
+				$pubkey_resource = openssl_pkey_get_public($pubkey);
+				if ($pubkey_resource)
+				{
+					$details = openssl_pkey_get_details($pubkey_resource);
+					if (array_key_exists('rsa', $details))
+					{
+						$fingerprint = sha1($details['rsa']['n'] . $details['rsa']['e']);
+					}
+				}
+
+				// Invalid public key.
+				if (!$fingerprint)
+				{
+					return $this->get_response("Error: invalid key");
+				}
+
+				// Reject duplicates.
+				$sql = 'SELECT COUNT(*) AS count
+					FROM ' . $key_table . '
+					WHERE fingerprint = "' . $this->db->sql_escape($fingerprint) . '"
+					OR public_key = "' . $this->db->sql_escape($pubkey) . '"';
+				$result = $this->db->sql_query($sql);
+				$duplicates = (int)$this->db->sql_fetchfield('count');
+				$this->db->sql_freeresult($result);
+
+				if ($duplicates)
+				{
+					return $this->get_response("Error: key exists");
+				}
+
+				$data = array(
+					'user_id' => (int)$login['user_row']['user_id'],
+					'public_key' => $pubkey,
+					'fingerprint' => $fingerprint,
+					'registered' => time()
+				);
+
+				$sql = 'INSERT INTO ' . $key_table . $this->db->sql_build_array('INSERT', $data);
+				$this->db->sql_query($sql);
+
+				return $this->get_response("Success");
+			}
+			else if ($login['status'] == LOGIN_ERROR_ATTEMPTS)
+			{
+				return $this->get_response("Error: too many login attempts");
+			}
+		}
+
+		return $this->get_response("Error: authentication failed");
+	}
+
 	public function get_response($content)
 	{
 		$response = new Response($content);
 		$response->headers->set('Content-Type', 'Content-type: text/plain; charset=utf-8');
 		return $response;
+	}
+
+	public function is_banned($user_id)
+	{
+		$sql = 'SELECT ban_exclude, ban_end
+			FROM ' . BANLIST_TABLE . "
+			WHERE ban_userid = " . $user_id;
+
+		$result = $this->db->sql_query($sql);
+		$banned = false;
+		while ($row = $this->db->sql_fetchrow($result))
+		{
+			if ($row['ban_end'] && $row['ban_end'] < time())
+			{
+				continue;
+			}
+
+			if (!empty($row['ban_exclude']))
+			{
+				$banned = false;
+				break;
+			}
+
+			$banned = true;
+		}
+
+		$this->db->sql_freeresult($result);
+		return $banned;
 	}
 }


### PR DESCRIPTION
`/openra/link` accept a POST request with username, password, and the public key generated by the game. This enables linking to be performed ingame, improving player experience.

It will return with one of:

| Result | Explanation |
| ------------- | -------------- |
| Success | Public key was successfully added to the account |
| Error: invalid key | Invalid key data was provided |
| Error: key exists | Key is already registered to an account |
| Error: banned | Forum account has been banned |
| Error: authentication failed | Invalid username or password |
| Error: too many login attempts | Too many incorrect auth attempts for the given user, or from the client's IP. These counters can be reset by waiting for the timeout (6h by default) or (re-)logging into the forum with a web browser and solving the captcha. |
